### PR TITLE
Update --commit option

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -41,5 +41,5 @@ jobs:
           git fetch origin master:master
           ruby -e "$(curl -s https://undercover-ci.com/uploader.rb)" -- \
             --repo grodowski/undercover-ci \
-            --commit $GITHUB_SHA \
+            --commit ${{ github.event.pull_request.head.sha || github.sha }} \
             --lcov coverage/lcov/undercover-ci.lcov

--- a/app/views/home/docs.html.erb
+++ b/app/views/home/docs.html.erb
@@ -154,7 +154,10 @@ Learn how to install UndercoverCI for your repos, report coverage data and use t
         The <code>$org/$repo</code> formatted name matching exactly how your repository appears on GitHub.
 
         <h6 class="mb-2 mt-3"><code>--commit</code></h6>
-        Current build commit SHA to identify on GitHub. This value will be provided by the CI build environment, e.g. <code>$CIRCLE_SHA1</code> for CircleCI, <code>${{ github.event.pull_request.head.sha }}</code> for GitHub Actions or <code>$TRAVIS_COMMIT</code> for TravisCI.</li>.
+        Current build commit SHA to identify on GitHub. This value will be provided by the CI build environment, e.g.
+        <code>$CIRCLE_SHA1</code> for CircleCI, <code>${{ github.event.pull_request.head.sha || github.sha }}</code> for
+        GitHub Actions or <code>$TRAVIS_COMMIT</code> for TravisCI.</li> Consult your CI service documentation to get the
+        right head SHA value for your build environment.
 
         <h6 class="mb-2 mt-3"><code>--lcov</code></h6>
         A relative path to the coverage report, will look like <code>coverage/lcov/$reponame.lcov</code> unless SimpleCov's config defaults were changed.

--- a/app/views/partials/_coverage_upload_instruction.html.erb
+++ b/app/views/partials/_coverage_upload_instruction.html.erb
@@ -80,7 +80,7 @@
                       bundle exec rake test
                       ruby -e "$(curl -s https://undercover-ci.com/uploader.rb)" -- \
                         --repo <b>${{ github.repository }}</b> \
-                        --commit <b>${{ github.sha }}</b> \
+                        --commit <b>${{ github.event.pull_request.head.sha || github.sha }}</b> \
                         --lcov <b>coverage/lcov/$repository-name.lcov</b>
             </code></pre>
           </li>


### PR DESCRIPTION
`{{ github.event.pull_request.head.sha || github.sha }}` determines the correct HEAD sha, avoiding virtual merge commit created for pull requests